### PR TITLE
Fix case sensitivity issue with entity linkification

### DIFF
--- a/system/expressionengine/third_party/twitter/mod.twitter.php
+++ b/system/expressionengine/third_party/twitter/mod.twitter.php
@@ -208,7 +208,7 @@ class Twitter
 					}
 				}
 
-				$val['text'] = str_replace($find, $replace, $val['text']);
+				$val['text'] = str_ireplace($find, $replace, $val['text']);
 
 				unset($find, $replace);
 			}


### PR DESCRIPTION
Some entities would not be replaced with their link wrapped
equivalents since they appeared in different case in the tweet.
For example, a username "Foo" might appear as "@foo" in a tweet,
and therefore would not be replaced since the find value works
off of the canonical screen_name "Foo" of the user.
