### PR TITLE
More logic added to images_only parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Set a prefix to use for the user tags (`{name}`, `{screen_name}`, `{location}`, 
 `images_only`
 
 Only return tweets that contain images. Options `yes`, `no`. Defaults to `no`
+When this is set to `yes`, urls to images in the tweet will also be removed from the tweet text.
 
 ####Single Variable Tags
 
@@ -133,7 +134,11 @@ Also, `{retweeter:*}` exists for all user fields for the retweeter, so for examp
 
 `{image}`
 
-The url to the image. This is essentially the same as `{medium}`, though the URL is slightly different.
+The direct url to the image. This is essentially the same as `{medium}`, though the URL is slightly different.
+
+`{display_url}`
+
+Url to the display page of twitpic
 
 `{[size]}`
 

--- a/system/expressionengine/third_party/twitter/mod.twitter.php
+++ b/system/expressionengine/third_party/twitter/mod.twitter.php
@@ -220,7 +220,10 @@ class Twitter
 								$find[] = $info['url'];
 								$displayurl = $info['url'];
 								if (isset($info['display_url'])) { $displayurl = $info['display_url']; }
-								$replace[]  = "<a target='".$this->target."' title='{$info['expanded_url']}' href='{$info['url']}'>{$displayurl}</a>";
+								if($images_only == FALSE)
+								{
+									$replace[]  = "<a target='".$this->target."' title='{$info['expanded_url']}' href='{$info['url']}'>{$displayurl}</a>";
+								}
 								if(isset($info['type']) && $info['type'] == 'photo')
 								{
 									$image = array(
@@ -230,6 +233,7 @@ class Twitter
 										$image = array_merge($image,
 											array(
 												'image' => $info['media_url'],
+												'display_url' => $info['expanded_url'],
 												$size => $info['media_url'] . ':' . $size,
 												$size . '_https' => $info['media_url_https'] . ':' . $size,
 												$size . '_w' => $sizeval['w'],


### PR DESCRIPTION
I've added a few features I needed myself for an implementation:

Now removes image url from text if images_only is set instead of adding an <a> tag.
Added display_url to {images}, links to the display page for the image.
