### PR TITLE
Allow multiple twitter users to be displayed in one feed.

### DIFF
--- a/system/expressionengine/third_party/twitter/mod.twitter.php
+++ b/system/expressionengine/third_party/twitter/mod.twitter.php
@@ -99,7 +99,7 @@ class Twitter
 			$statuses = array_merge($statuses, $this->_fetch_data($url, $params));
 		}
 
-		usort($statuses, function (array $a, array $b) { return strtotime($a["created_at"]) - strtotime($b["created_at"]); });
+		usort($statuses, function (array $a, array $b) { return strtotime($b["created_at"]) - strtotime($a["created_at"]); });
 
 		if ( ! $statuses)
 		{


### PR DESCRIPTION
Multiple twitter usernames can be specified in a pipe separated list.
Tweets from each of these users will then be shown in a single feed.

Example:

```
{exp:twitter:user screen_name="twitter|Support" limit="3" retweets="no"
replies="no"}
<li><a href="https://twitter.com/{screen_name}/"><strong>@{screen_name}</strong></a> - {text}</li>
{/exp:twitter:user}
```
