### PR TITLE
Fix missing check that access_token and access_token_secret are set

### DIFF
--- a/system/expressionengine/third_party/twitter/mod.twitter.php
+++ b/system/expressionengine/third_party/twitter/mod.twitter.php
@@ -678,8 +678,8 @@ class Twitter
 		$settings = $this->EE->twitter_model->get_settings();
 
 		// Read in our saved access token/secret
-		$access_token = $settings['access_token'];
-		$access_token_secret = $settings['access_token_secret'];
+		$access_token = isset($settings['access_token']) ? $settings['access_token'] : FALSE;
+		$access_token_secret = isset($settings['access_token_secret']) ? $settings['access_token_secret'] : FALSE;
 
 		// Create our twitter API object
 		$oauth = new TwitterEETwitter_OAuth($settings['consumer_key'], $settings['consumer_secret'], $access_token, $access_token_secret);


### PR DESCRIPTION
In views/index.php, you check that both `$settings['access_token']` and `$settings['access_token_secret']` are set, otherwise setting them to false. This check wasn’t being made in mod.twitter.php, which was raising `Undefined index: access token` and `Undefined index: access  token_secret` for me when using the `{exp:twitter:user}` tag.

This commit defaults those settings to `FALSE` to avoid this error, as was already done in views/index.php
